### PR TITLE
Add skipping of provider registration

### DIFF
--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -18,6 +18,7 @@ terraform {
 }
 
 provider "azurerm" {
+  skip_provider_registration = true
   features {
   }
 }


### PR DESCRIPTION
This pull request adds the ability to skip provider registration in the Terraform configuration. The `skip_provider_registration` flag is set to true in the `azurerm` provider block, allowing the provider registration step to be skipped during deployment.